### PR TITLE
Adding Github-project-landing-page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -196,3 +196,6 @@
 [submodule "ghostwriter"]
 	path = ghostwriter
 	url = https://github.com/jbub/ghostwriter.git
+[submodule "github-project-landing-page"]
+	path = github-project-landing-page
+	url = https://github.com/oarrabi/github-project-landing-page.git


### PR DESCRIPTION
Github landing page is a theme designed to quickly create a landing page for a project hosted on github.
A demo can be found at http://swiftline.github.io

The theme contains variables in the Toml file to quickly setup the links for a github project landing page.
In addition, you can change the first, secondary and header background and foreground colors.