### PR TITLE
Remove duplicate base16 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -202,6 +202,3 @@
 [submodule "github-project-landing-page"]
 	path = github-project-landing-page
 	url = https://github.com/oarrabi/github-project-landing-page.git
-[submodule "base16"]
-	path = base16
-	url = https://github.com/htdvisser/hugo-base16-theme.git


### PR DESCRIPTION
Duplicate of base16 theme definition broke git clone:

```
git clone --depth 1 --recursive https://github.com/spf13/hugoThemes.git themes
Cloning into 'themes'...
remote: Counting objects: 5, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 5 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (5/5), done.
Checking connectivity... done.
Submodule 'agency' (https://github.com/digitalcraftsman/hugo-agency-theme.git) registered for path 'agency'
Submodule 'aglaus' (https://github.com/dim0627/hugo_theme_aglaus) registered for path 'aglaus'
Submodule 'air' (https://github.com/syui/hugo-theme-air.git) registered for path 'air'
Submodule 'allegiant' (https://github.com/brycematheson/allegiant.git) registered for path 'allegiant'
Submodule 'angels-ladder' (https://github.com/tanksuzuki/angels-ladder.git) registered for path 'angels-ladder'
Submodule 'artists' (https://github.com/digitalcraftsman/hugo-artists-theme.git) registered for path 'artists'
error: invalid key (newline): submodule.base16
base16.url
error: invalid key (newline): submodule.base16
base16.url
No url found for submodule path 'base16' in .gitmodules
```
Should be removed